### PR TITLE
Improve mobile nav and social media spacing

### DIFF
--- a/components/navbar.jsx
+++ b/components/navbar.jsx
@@ -1,22 +1,32 @@
+import { useState } from 'react';
 import styles from '../styles/navbar.module.css';
 
 export default function NavBar() {
+    const [open, setOpen] = useState(false);
+
+    const toggleMenu = () => setOpen(!open);
+
     return (
-        <div className={styles.stickyNav} id="stickyNav">
-            <ul className={styles.navList}>
+        <nav className={styles.stickyNav} id="stickyNav">
+            <div className={styles.hamburger} onClick={toggleMenu}>
+                <span className={styles.bar}></span>
+                <span className={styles.bar}></span>
+                <span className={styles.bar}></span>
+            </div>
+            <ul className={`${styles.navList} ${open ? styles.showMenu : ''}`}>
                 <li>
-                    <a href="#about" className={styles.navLink}>About</a>
+                    <a href="#about" className={styles.navLink} onClick={() => setOpen(false)}>About</a>
                 </li>
                 <li>
-                    <a href="#projects" className={styles.navLink}>Projects</a>
+                    <a href="#projects" className={styles.navLink} onClick={() => setOpen(false)}>Projects</a>
                 </li>
                 <li>
-                    <a href="#timeline" className={styles.navLink}>Experiences</a>
+                    <a href="#timeline" className={styles.navLink} onClick={() => setOpen(false)}>Experiences</a>
                 </li>
                 <li>
-                    <a href="#contact" className={styles.navLink}>Contact</a>
+                    <a href="#contact" className={styles.navLink} onClick={() => setOpen(false)}>Contact</a>
                 </li>
             </ul>
-        </div>
+        </nav>
     )
 }

--- a/styles/about.module.css
+++ b/styles/about.module.css
@@ -250,14 +250,14 @@
         font-size: 5rem;
         transition:  color 450ms, transform 300ms;
         color: rgba(255, 255, 255, 0.89);
-        width: 100%;
     }
 
     .navListMobile {
         display: flex;
         width: 100%;
         margin: auto;
-        justify-content: space-evenly;
+        justify-content: center;
+        gap: 2rem;
     }
     .navListMobile li{
     list-style: none;

--- a/styles/navbar.module.css
+++ b/styles/navbar.module.css
@@ -47,9 +47,43 @@
 .stickyNav .sticky{
     border: none;
 }
+
+.hamburger{
+    display: none;
+    flex-direction: column;
+    cursor: pointer;
+    padding: 1rem;
+}
+
+.bar{
+    width: 25px;
+    height: 3px;
+    background-color: #e6e6e6;
+    margin: 4px 0;
+}
+
+.showMenu{
+    display: flex !important;
+}
+
 @media(Max-width:800px){
     .stickyNav{
+        display: flex;
+        justify-content: flex-end;
+    }
+    .stickyNav .navList{
         display: none;
+        flex-direction: column;
+        width: 100%;
+        padding: 1rem 0;
+        align-items: center;
+        background: rgba(10, 10, 25, 0.8);
+    }
+    .stickyNav .navList li{
+        margin: 1rem 0;
+    }
+    .hamburger{
+        display: flex;
     }
 }
 


### PR DESCRIPTION
## Summary
- Space social media icons evenly on mobile
- Add hamburger menu for mobile navigation links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bd0c7e1588327b4f8bce29c7dd1c1